### PR TITLE
Add web interface for voice agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,32 @@ Research and Innovation: Staying updated with the latest advancements in AI to e
 Interdisciplinary Collaboration: Combining knowledge from various domains such as computer vision, robotics, and natural language processing to create comprehensive AI solutions.
 Scalable Solutions: Focusing on building scalable and efficient models that can be deployed in real-world applications.
 These projects not only enhanced my technical skills but also reinforced the importance of creativity, critical thinking, and teamwork in AI development. They stand as a testament to my commitment to learning and my ability to translate knowledge into impactful solutions.
+
+## Voice Agent Simulator
+
+This project includes a basic restaurant voice agent with two ways to try it:
+
+1. **Command line** – run `voice_agent_sim.py` to simulate a call.
+2. **Web UI** – open `voice_agent_web/index.html` for an app-like experience using HTML, CSS, JavaScript, and GSAP animations.
+
+### Download
+
+```bash
+git clone <repository-url>
+cd AI_Projects
+```
+
+Or download the repository as a ZIP archive and extract it.
+
+### Run the Command-Line Version
+
+```bash
+python3 voice_agent_sim.py inbound
+```
+
+Replace `inbound` with `outbound` to simulate an outbound call.
+
+### Run the Web Version
+
+Simply open `voice_agent_web/index.html` in your web browser. No server setup is required.
+

--- a/voice_agent_sim.py
+++ b/voice_agent_sim.py
@@ -1,0 +1,73 @@
+import argparse
+
+MENU = {
+    "pizza": {
+        "price": 12.0,
+        "sizes": ["small", "medium", "large"]
+    },
+    "salad": {
+        "price": 8.0,
+        "sizes": ["regular", "large"]
+    },
+    "water": {
+        "price": 2.0,
+        "sizes": ["bottle"]
+    }
+}
+
+class VoiceAgent:
+    def __init__(self, menu):
+        self.menu = menu
+        self.order = []
+
+    def start_call(self, call_type: str = "inbound"):
+        if call_type == "outbound":
+            print("Placing an outbound call...")
+        else:
+            print("Incoming call answered...")
+        print("Hello! Welcome to our restaurant.")
+        self.present_menu()
+        self.take_order()
+        self.summarize_order()
+
+    def present_menu(self):
+        print("Our menu items:")
+        for item, info in self.menu.items():
+            print(f"- {item} (${info['price']}) sizes: {', '.join(info['sizes'])}")
+
+    def take_order(self):
+        while True:
+            item = input("Enter item name (or 'done' to finish): ").strip().lower()
+            if item == 'done':
+                break
+            if item not in self.menu:
+                print("Item not found. Try again.")
+                continue
+            size = input(f"Enter size for {item}: ").strip().lower()
+            if size not in self.menu[item]['sizes']:
+                print("Invalid size. Try again.")
+                continue
+            qty = input("Quantity: ").strip()
+            if not qty.isdigit() or int(qty) <= 0:
+                print("Invalid quantity. Try again.")
+                continue
+            self.order.append({"item": item, "size": size, "qty": int(qty)})
+            print(f"Added {qty} {size} {item}(s).")
+
+    def summarize_order(self):
+        total = 0
+        print("\nOrder summary:")
+        for entry in self.order:
+            price = self.menu[entry['item']]['price'] * entry['qty']
+            total += price
+            print(f"{entry['qty']} x {entry['size']} {entry['item']} - ${price:.2f}")
+        print(f"Total: ${total:.2f}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Simulate a restaurant voice agent")
+    parser.add_argument("call_type", nargs="?", default="inbound", choices=["inbound", "outbound"], help="Type of call to simulate")
+    args = parser.parse_args()
+
+    agent = VoiceAgent(MENU)
+    print("Welcome to the Restaurant Voice Agent Simulator!")
+    agent.start_call(args.call_type)

--- a/voice_agent_web/app.js
+++ b/voice_agent_web/app.js
@@ -1,0 +1,82 @@
+const MENU = {
+    pizza: { price: 12.0, sizes: ["small", "medium", "large"] },
+    salad: { price: 8.0, sizes: ["regular", "large"] },
+    water: { price: 2.0, sizes: ["bottle"] }
+};
+
+const callSetup = document.getElementById('call-setup');
+const orderSection = document.getElementById('order-section');
+const summarySection = document.getElementById('summary-section');
+const itemSelect = document.getElementById('item-select');
+const sizeSelect = document.getElementById('size-select');
+const qtyInput = document.getElementById('qty-input');
+const orderList = document.getElementById('order-list');
+const summaryDiv = document.getElementById('summary');
+
+let order = [];
+
+function populateItems() {
+    itemSelect.innerHTML = '';
+    Object.keys(MENU).forEach(item => {
+        const opt = document.createElement('option');
+        opt.value = item;
+        opt.textContent = item;
+        itemSelect.appendChild(opt);
+    });
+    updateSizes();
+}
+
+function updateSizes() {
+    const item = itemSelect.value;
+    sizeSelect.innerHTML = '';
+    MENU[item].sizes.forEach(size => {
+        const opt = document.createElement('option');
+        opt.value = size;
+        opt.textContent = size;
+        sizeSelect.appendChild(opt);
+    });
+}
+
+function addItem() {
+    const item = itemSelect.value;
+    const size = sizeSelect.value;
+    const qty = parseInt(qtyInput.value, 10);
+    if (!qty || qty < 1) return;
+    order.push({ item, size, qty });
+    const li = document.createElement('li');
+    li.textContent = `${qty} x ${size} ${item}`;
+    orderList.appendChild(li);
+}
+
+function finishOrder() {
+    let total = 0;
+    summaryDiv.innerHTML = '';
+    order.forEach(entry => {
+        const price = MENU[entry.item].price * entry.qty;
+        total += price;
+        const p = document.createElement('p');
+        p.textContent = `${entry.qty} x ${entry.size} ${entry.item} - $${price.toFixed(2)}`;
+        summaryDiv.appendChild(p);
+    });
+    const totalP = document.createElement('p');
+    totalP.textContent = `Total: $${total.toFixed(2)}`;
+    summaryDiv.appendChild(totalP);
+    gsap.to(orderSection, { duration: 0.5, opacity: 0, onComplete: () => {
+        orderSection.classList.add('hidden');
+        gsap.fromTo(summarySection, { opacity: 0 }, { opacity: 1, duration: 0.5 });
+        summarySection.classList.remove('hidden');
+    }});
+}
+
+document.getElementById('start-btn').addEventListener('click', () => {
+    populateItems();
+    gsap.to(callSetup, { duration: 0.5, opacity: 0, onComplete: () => {
+        callSetup.classList.add('hidden');
+        gsap.fromTo(orderSection, { opacity: 0 }, { opacity: 1, duration: 0.5 });
+        orderSection.classList.remove('hidden');
+    }});
+});
+
+itemSelect.addEventListener('change', updateSizes);
+document.getElementById('add-item').addEventListener('click', addItem);
+document.getElementById('finish-order').addEventListener('click', finishOrder);

--- a/voice_agent_web/index.html
+++ b/voice_agent_web/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Restaurant Voice Agent</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+</head>
+<body>
+<div id="app">
+    <h1>Restaurant Voice Agent</h1>
+    <div id="call-setup">
+        <label for="call-type">Call Type:</label>
+        <select id="call-type">
+            <option value="inbound">Inbound</option>
+            <option value="outbound">Outbound</option>
+        </select>
+        <button id="start-btn">Start Call</button>
+    </div>
+    <div id="order-section" class="hidden">
+        <h2>Menu</h2>
+        <div id="item-form">
+            <label for="item-select">Item:</label>
+            <select id="item-select"></select>
+            <label for="size-select">Size:</label>
+            <select id="size-select"></select>
+            <label for="qty-input">Qty:</label>
+            <input id="qty-input" type="number" min="1" value="1">
+            <button id="add-item">Add Item</button>
+        </div>
+        <ul id="order-list"></ul>
+        <button id="finish-order">Finish Order</button>
+    </div>
+    <div id="summary-section" class="hidden">
+        <h2>Order Summary</h2>
+        <div id="summary"></div>
+    </div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/voice_agent_web/style.css
+++ b/voice_agent_web/style.css
@@ -1,0 +1,31 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #fafafa;
+    margin: 0;
+    padding: 20px;
+}
+
+h1 {
+    text-align: center;
+}
+
+#call-setup, #order-section, #summary-section {
+    margin: 20px auto;
+    max-width: 600px;
+    padding: 20px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+label {
+    margin-right: 5px;
+}
+
+button {
+    margin-top: 10px;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- add a simple browser interface under `voice_agent_web` using HTML/CSS/JS with GSAP animations
- update README with instructions for running the command-line and web versions of the voice agent

## Testing
- `pytest -q`
- `python3 voice_agent_sim.py inbound <<'EOF'
pizza
large
2
salad
regular
1
done
EOF`
- `python3 voice_agent_sim.py outbound <<'EOF'
water
bottle
1
done
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68618bb2344c8326bbb32535f73224a8